### PR TITLE
Follow C# norms by capitalizing method names

### DIFF
--- a/csharp/EncodeKata/SessionModificationCmd.cs
+++ b/csharp/EncodeKata/SessionModificationCmd.cs
@@ -22,19 +22,19 @@ namespace EncodeKata
             this.srypId = SRYP.SessionManagement;
         }
 
-        public void setXyzTimer(XyzTimerUnit unit, int timerValue)
+        public void SetXyzTimer(XyzTimerUnit unit, int timerValue)
         {
             this.hasXyzTimer = true;
-            this.xyzTimer.set(unit, timerValue);
+            this.xyzTimer.Set(unit, timerValue);
         }
 
-        public void setPqvl(int value)
+        public void SetPqvl(int value)
         {
             this.hasPqvl = true;
             this.pqvl = value;
         }   
 
-        public void encode(ByteBuffer data)
+        public void Encode(ByteBuffer data)
         {
             data.Append((int)this.srypId);
             data.Append(this.sessionId);
@@ -43,7 +43,7 @@ namespace EncodeKata
 
             if (this.hasXyzTimer)
             {
-                this.xyzTimer.encode(data);
+                this.xyzTimer.Encode(data);
             }
             if (this.hasPqvl)
             {
@@ -62,13 +62,13 @@ namespace EncodeKata
         private XyzTimerUnit timerUnit;
         private int timerValue;
 
-        public void set(XyzTimerUnit unit, int timerValue)
+        public void Set(XyzTimerUnit unit, int timerValue)
         {
             this.timerUnit = unit;
             this.timerValue = timerValue;
         }
 
-        public void encode(ByteBuffer data)
+        public void Encode(ByteBuffer data)
         {
             data.Append((int)YEW.YewXyzTimer);
             int temp;

--- a/csharp/EncodeTests/EncodeNUnitTest.cs
+++ b/csharp/EncodeTests/EncodeNUnitTest.cs
@@ -17,19 +17,19 @@ class EncodeNUnitTest
         var hex = new HexStringEncoder();
         var hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
-        Assert.AreEqual(hexStr, "03010101083791");
+        Assert.AreEqual("03010101083791", hexStr);
 
         command.SetXyzTimer(XyzTimerUnit.MultipliesOfMinutes, 32); // outside range(31), expect 31
         command.Encode(data);
         hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
-        Assert.AreEqual(hexStr, "03010101085f91");
+        Assert.AreEqual( "03010101085f91", hexStr);
 
         command.SetXyzTimer(XyzTimerUnit.TimerDeactivated, 2); // deactivated, expect value 0
         command.Encode(data);
         hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
-        Assert.AreEqual(hexStr, "03010101080091");
+        Assert.AreEqual( "03010101080091", hexStr);
     }
 
     public class HexStringEncoder

--- a/csharp/EncodeTests/EncodeNUnitTest.cs
+++ b/csharp/EncodeTests/EncodeNUnitTest.cs
@@ -11,30 +11,30 @@ class EncodeNUnitTest
     {
         var command = new SessionModificationCmd(1, 1);
         var data = new ByteBuffer();
-        command.setXyzTimer(XyzTimerUnit.MultiplesOfHours, 23);
-        command.setPqvl(1);
-        command.encode(data);
+        command.SetXyzTimer(XyzTimerUnit.MultiplesOfHours, 23);
+        command.SetPqvl(1);
+        command.Encode(data);
         var hex = new HexStringEncoder();
-        var hexStr = hex.encode(data);
+        var hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
         Assert.AreEqual(hexStr, "03010101083791");
 
-        command.setXyzTimer(XyzTimerUnit.MultipliesOfMinutes, 32); // outside range(31), expect 31
-        command.encode(data);
-        hexStr = hex.encode(data);
+        command.SetXyzTimer(XyzTimerUnit.MultipliesOfMinutes, 32); // outside range(31), expect 31
+        command.Encode(data);
+        hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
         Assert.AreEqual(hexStr, "03010101085f91");
 
-        command.setXyzTimer(XyzTimerUnit.TimerDeactivated, 2); // deactivated, expect value 0
-        command.encode(data);
-        hexStr = hex.encode(data);
+        command.SetXyzTimer(XyzTimerUnit.TimerDeactivated, 2); // deactivated, expect value 0
+        command.Encode(data);
+        hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
         Assert.AreEqual(hexStr, "03010101080091");
     }
 
     public class HexStringEncoder
     {
-        public string encode(ByteBuffer buffer)
+        public string Encode(ByteBuffer buffer)
         {
             string str = "";
             while (buffer.GetAvailable() > 0)

--- a/csharp/EncodeTests/EncodeXUnitTest.cs
+++ b/csharp/EncodeTests/EncodeXUnitTest.cs
@@ -11,30 +11,30 @@ public class EncodeXUnitTest
     {
         var command = new SessionModificationCmd(1, 1);
         var data = new ByteBuffer();
-        command.setXyzTimer(XyzTimerUnit.MultiplesOfHours, 23);
-        command.setPqvl(1);
-        command.encode(data);
+        command.SetXyzTimer(XyzTimerUnit.MultiplesOfHours, 23);
+        command.SetPqvl(1);
+        command.Encode(data);
         var hex = new HexStringEncoder();
-        var hexStr = hex.encode(data);
+        var hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
         Assert.Equal("03010101083791", hexStr);
 
-        command.setXyzTimer(XyzTimerUnit.MultipliesOfMinutes, 32); // outside range(31), expect 31
-        command.encode(data);
-        hexStr = hex.encode(data);
+        command.SetXyzTimer(XyzTimerUnit.MultipliesOfMinutes, 32); // outside range(31), expect 31
+        command.Encode(data);
+        hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
         Assert.Equal("03010101085f91", hexStr);
         
-        command.setXyzTimer(XyzTimerUnit.TimerDeactivated, 2); // deactivated, expect value 0
-        command.encode(data);
-        hexStr = hex.encode(data);
+        command.SetXyzTimer(XyzTimerUnit.TimerDeactivated, 2); // deactivated, expect value 0
+        command.Encode(data);
+        hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");
         Assert.Equal("03010101080091", hexStr);
     }
 
     public class HexStringEncoder
     {
-        public string encode(ByteBuffer buffer)
+        public string Encode(ByteBuffer buffer)
         {
             string str = "";
             while (buffer.GetAvailable() > 0)


### PR DESCRIPTION
To reduce cognitive load on students.