### PR TITLE
Fix typo to avoid derailing participants

### DIFF
--- a/cpp/src/XyzTimer.h
+++ b/cpp/src/XyzTimer.h
@@ -6,7 +6,7 @@
 #include "ByteBuffer.h"
 
 enum XyzTimerUnit {
-    TimerDeactivated, MultiplesOfHours, MultipliesOfMinutes, MultiplesOfSeconds
+    TimerDeactivated, MultiplesOfHours, MultiplesOfMinutes, MultiplesOfSeconds
 };
 
 

--- a/cpp/test-catch2/session_catch.cpp
+++ b/cpp/test-catch2/session_catch.cpp
@@ -19,7 +19,7 @@ TEST_CASE ("SessionModificationCmd") {
     cout << "Hex: " << hexStr << endl;
     REQUIRE(hexStr == "03010101083791");
 
-    command.setXyzTimer(MultipliesOfMinutes, 32); // outside range(31), expect 31
+    command.setXyzTimer(MultiplesOfMinutes, 32); // outside range(31), expect 31
     command.encode(data);
     hexStr = hex.encode(data);
     cout << "Hex: " << hexStr << endl;

--- a/cpp/test-doctest/session_doctest.cpp
+++ b/cpp/test-doctest/session_doctest.cpp
@@ -18,7 +18,7 @@ TEST_CASE("SessionModificationCmd") {
     cout << "Hex: " << hexStr << endl;
     REQUIRE(hexStr == "03010101083791");
 
-    command.setXyzTimer(MultipliesOfMinutes, 32); // outside range(31), expect 31
+    command.setXyzTimer(MultiplesOfMinutes, 32); // outside range(31), expect 31
     command.encode(data);
     hexStr = hex.encode(data);
     cout << "Hex: " << hexStr << endl;

--- a/cpp/test-gtest/session_gtest.cpp
+++ b/cpp/test-gtest/session_gtest.cpp
@@ -19,7 +19,7 @@ TEST(MessageTest, SessionModificationCmd) {
     cout << "Hex: " << hexStr << endl;
     ASSERT_EQ(hexStr, "03010101083791");
 
-    command.setXyzTimer(MultipliesOfMinutes, 32); // outside range(31), expect 31
+    command.setXyzTimer(MultiplesOfMinutes, 32); // outside range(31), expect 31
     command.encode(data);
     hexStr = hex.encode(data);
     cout << "Hex: " << hexStr << endl;

--- a/csharp/EncodeKata/SessionModificationCmd.cs
+++ b/csharp/EncodeKata/SessionModificationCmd.cs
@@ -110,7 +110,7 @@ namespace EncodeKata
     {
         TimerDeactivated,
         MultiplesOfHours,
-        MultipliesOfMinutes,
+        MultiplesOfMinutes,
         MultiplesOfSeconds,
     };
 }

--- a/csharp/EncodeTests/EncodeNUnitTest.cs
+++ b/csharp/EncodeTests/EncodeNUnitTest.cs
@@ -19,7 +19,7 @@ class EncodeNUnitTest
         Console.Write("Hex: " + hexStr + "\n");
         Assert.AreEqual("03010101083791", hexStr);
 
-        command.SetXyzTimer(XyzTimerUnit.MultipliesOfMinutes, 32); // outside range(31), expect 31
+        command.SetXyzTimer(XyzTimerUnit.MultiplesOfMinutes, 32); // outside range(31), expect 31
         command.Encode(data);
         hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");

--- a/csharp/EncodeTests/EncodeXUnitTest.cs
+++ b/csharp/EncodeTests/EncodeXUnitTest.cs
@@ -19,7 +19,7 @@ public class EncodeXUnitTest
         Console.Write("Hex: " + hexStr + "\n");
         Assert.Equal("03010101083791", hexStr);
 
-        command.SetXyzTimer(XyzTimerUnit.MultipliesOfMinutes, 32); // outside range(31), expect 31
+        command.SetXyzTimer(XyzTimerUnit.MultiplesOfMinutes, 32); // outside range(31), expect 31
         command.Encode(data);
         hexStr = hex.Encode(data);
         Console.Write("Hex: " + hexStr + "\n");

--- a/java/src/main/java/org/codingdojo/kata/encode/XyzTimerUnit.java
+++ b/java/src/main/java/org/codingdojo/kata/encode/XyzTimerUnit.java
@@ -3,6 +3,6 @@ package org.codingdojo.kata.encode;
 public enum XyzTimerUnit {
     TIMER_DEACTIVATED,
     MULTIPLES_OF_HOURS,
-    MULTIPLIES_OF_MINUTES,
+    MULTIPLES_OF_MINUTES,
     MULTIPLES_OF_SECONDS
 }

--- a/java/src/test/java/org/codingdojo/kata/encode/EncodeTest.java
+++ b/java/src/test/java/org/codingdojo/kata/encode/EncodeTest.java
@@ -21,7 +21,7 @@ final class EncodeTest {
         System.out.println("Hex: " + hexStr + "\n");
         assertEquals("03010101083791", hexStr);
 
-        command.setXyzTimer(XyzTimerUnit.MULTIPLIES_OF_MINUTES, 32); // outside range(31), expect 31
+        command.setXyzTimer(XyzTimerUnit.MULTIPLES_OF_MINUTES, 32); // outside range(31), expect 31
         command.encode(data);
         hexStr = hex.encode(data);
         System.out.println("Hex: " + hexStr + "\n");

--- a/swift/Sources/Encode-TestDesign-Kata/SessionModificationCmd.swift
+++ b/swift/Sources/Encode-TestDesign-Kata/SessionModificationCmd.swift
@@ -85,6 +85,6 @@ enum MessageType: Int {
 enum XyzTimerUnit: Int {
     case timerDeactivated
     case multiplesOfHours
-    case multipliesOfMinutes
+    case multiplesOfMinutes
     case multiplesOfSeconds
 }

--- a/swift/Tests/Encode-TestDesign-KataTests/EncodeTests.swift
+++ b/swift/Tests/Encode-TestDesign-KataTests/EncodeTests.swift
@@ -14,7 +14,7 @@ class EncodeTests: XCTestCase {
         print("Hex: \(hexStr)")
         XCTAssertEqual(hexStr, "03010101083791")
 
-        command.setXyzTimer(unit: .multipliesOfMinutes, timerValue: 32) // outside range(31), expect 31
+        command.setXyzTimer(unit: .multiplesOfMinutes, timerValue: 32) // outside range(31), expect 31
         command.encode(data)
         let hexStr2 = hex.encode(data)
         print("Hex: \(hexStr2)")


### PR DESCRIPTION
"multiples of minutes" had a typo, multiplies. Easy to overlook as our IDEs recognized "multiplies" as a valid word, not a typo.

But the Python version was correct!